### PR TITLE
[N05] OpenZeppelin Contract’s dependency is not pinned

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "web3": "^1.2.7"
     },
     "dependencies": {
-        "@openzeppelin/contracts": "^3.0.1",
+        "@openzeppelin/contracts": "3.0.1",
         "@uniswap/v2-core": "^1.0.1",
         "@uniswap/v2-periphery": "^1.1.0-beta.0",
         "bip39": "^3.0.2",


### PR DESCRIPTION
## Fixes
- Pins dependency.