### PR TITLE
Adds functions to registry to pause and unpause deployOptions func.

### DIFF
--- a/contracts/option/applications/Registry.sol
+++ b/contracts/option/applications/Registry.sol
@@ -53,6 +53,20 @@ contract Registry is IRegistry, Ownable, Pausable, ReentrancyGuard {
     }
 
     /**
+     * @dev Pauses the deployOption function.
+     */
+    function pauseDeployments() external override onlyOwner {
+        _pause();
+    }
+
+    /**
+     * @dev Unpauses the deployOption function.
+     */
+    function unpauseDeployments() external override onlyOwner {
+        _unpause();
+    }
+
+    /**
      * @dev Sets the option factory contract to use for deploying clones.
      * @param optionFactory_ The address of the option factory.
      */

--- a/contracts/option/interfaces/IRegistry.sol
+++ b/contracts/option/interfaces/IRegistry.sol
@@ -3,6 +3,10 @@
 pragma solidity 0.6.2;
 
 interface IRegistry {
+    function pauseDeployments() external;
+
+    function unpauseDeployments() external;
+
     function deployOption(
         address underlyingToken,
         address strikeToken,


### PR DESCRIPTION
## Description
- Adds functions to call _pause() and _unpause() internal functions in Registry.sol inherited from Pausable contract by Open Zeppelin.